### PR TITLE
Put vias on all copper layers

### DIFF
--- a/convertpcb.pl
+++ b/convertpcb.pl
@@ -1549,10 +1549,10 @@ EOF
       my $altlayer=unpack("C",substr($value,$pos+23,1));
   	  assertdata("Pad",$counter,"LAYER",$altlayername{$altlayer});
 
-      my $layer=mapLayer($altlayer) || "F.Cu"; $layer="F.Cu B.Cu" if($altlayer==74);
+      my $layer=mapLayer($altlayer) || "F.Cu"; $layer="*.Cu" if($altlayer==74);
 	  
-	  $layer.=" F.Mask F.Paste" if($layer=~m/F\.Cu/);
-	  $layer.=" B.Mask B.Paste" if($layer=~m/B\.Cu/);
+	  $layer.=" F.Mask F.Paste" if($layer=~m/[F\*]\.Cu/);
+	  $layer.=" B.Mask B.Paste" if($layer=~m/[B\*]\.Cu/);
 
 	  my $sx=bmil2mm(substr($value,$pos+44,4));
 	  my $sy=bmil2mm(substr($value,$pos+48,4));


### PR DESCRIPTION
This fixes an additional ~50 ratsnest on the Cryptech Alpha board. I think most (all?) of the remaining ones (81) are due to via stitching apparently not working without a one-pad component in KiCad (one does not seem to be able to assign a lonely via to a net).
