### PR TITLE
Schematic fixes

### DIFF
--- a/convertschema.pl
+++ b/convertschema.pl
@@ -658,7 +658,7 @@ EOF
 		my $LINEWIDTH=$d{LINEWIDTH}||1;
 		drawcomponent "C $x $y ".(($d{'RADIUS'}||0)*$f)." 0 1 $LINEWIDTH"."0 $fill\n";
 	  }
-	  elsif($d{'RECORD'} eq '12') # Arc
+      elsif($d{'RECORD'} eq '12' || $d{'RECORD'} eq '11') # Arc or Elliptical arc (we ignore the secondary axis as KiCad doesn't support it)
 	  {
 	    #RECORD=12|ENDANGLE=180.000|LINEWIDTH=1|LOCATION.X=1065|LOCATION.Y=700|OWNERINDEX=738|RADIUS=5|STARTANGLE=90.000|		
         my $x=($d{'LOCATION.X'}*$f)-$relx;
@@ -667,6 +667,7 @@ EOF
 		my $r=int(($d{'RADIUS'}||0)+(($d{'RADIUS_FRAC'}||0)/100000.0))*$f;
 		my $sa="0"; $sa="$1$2" if(defined($d{'STARTANGLE'}) && $d{'STARTANGLE'}=~m/(\d+)\.(\d)(\d+)/);
 		my $ea="3600"; $ea="$1$2" if(defined($d{'ENDANGLE'}) && $d{'ENDANGLE'}=~m/(\d+)\.(\d)(\d+)/);
+        $sa+=1800, $ea+=1800 if ( $d{'RECORD'} eq '11' );  # Hack for elliptical arcs
 		my @liste=();
 		if(($ea-$sa)>=1800)
 		{
@@ -734,13 +735,6 @@ EOF
 		($cx,$cy)=rotate($cx,$cy,$partorientation{$globalp});
 		drawcomponent "S $x $y $cx $cy 0 1 10 f\n";
       }
-	  elsif($d{'RECORD'} eq '11') # Ellipse ???
-	  {
-	    print "Ellipses are not yet supported by KiCAD\n";
-		#RADIUS=9|RADIUS_FRAC=93698|SECONDARYRADIUS=5|SECONDARYRADIUS_FRAC=4539
-		#LOCATION.X=130|LOCATION.Y=90|
-		#LINEWIDTH=1|STARTANGLE=0.809|ENDANGLE=179.510|COLOR=16711680
-	  }
 	  elsif($d{'RECORD'} eq '29') # Junction
 	  {
 	    #RECORD=29|OWNERPARTID=  -1|OWNERINDEX=   0|LOCATION.X=130|LOCATION.Y=1230|

--- a/convertschema.pl
+++ b/convertschema.pl
@@ -54,6 +54,7 @@ our $timestamp=$start_time;  # this value gets decreased every time we need a un
 my %hvmap=("0"=>"H","1"=>"V","2"=>"H","3"=>"V");
 our %uniquereferences=();
 my %myrot=("0"=>"0","90"=>"1","270"=>"2");
+my %iotypes=("0"=>"BiDi","1"=>"Input","2"=>"Output"); # Others unknown yet
 
 #Reads a file with one function
 sub readfile($)
@@ -1288,9 +1289,19 @@ EOF
 	  {
 	    # References $d{'FILENAME'} as a filepath, but this likely does not exist
 	  }
-	  elsif($d{'RECORD'} eq '18')
+	  elsif($d{'RECORD'} eq '18') # Port
 	  {
-	    print "RECORD=18: $b\n";
+        #RECORD=18|INDEXINSHEET=75|OWNERPARTID=-1|STYLE=3|IOTYPE=1|ALIGNMENT=1|WIDTH=60|LOCATION.X=510|LOCATION.Y=990|COLOR=128|FONTID=1|AREACOLOR=8454143|TEXTCOLOR=128|NAME=ADC_VIN|UNIQUEID=ANXOUWEQ|HEIGHT=10
+        #RECORD=18|INDEXINSHEET=73|OWNERPARTID=-1|STYLE=3|ALIGNMENT=1|WIDTH=45|LOCATION.X=625|LOCATION.Y=325|COLOR=128|FONTID=1|AREACOLOR=8454143|TEXTCOLOR=128|NAME=GPIO_IF|HARNESSTYPE=GPIO|UNIQUEID=RNYSNNOD|HEIGHT=10
+        # No support for HARNESSTYPE yet (KiCad doesn't have such a feature)  We could instantiate lots of Ports as per the .Hardness file definition, but how would we lay them out?
+        # Location for Input/Output works, but for BiDi it doesn't connect - need some manual adjustment, as we can't use the WIDTH property in a KiCad global label
+        my $x=($d{'LOCATION.X'}*$f);
+        my $y=$sheety-($d{'LOCATION.Y'}*$f);
+        my $orientation=$d{'ALIGNMENT'}+1 || 0; # Altium seems to ignore this for harnesses?
+        my $shape=$iotypes{$d{'IOTYPE'} || 0 }; # Altium never seems to write out IOTYPE=0 for BiDi's
+        my $name=$d{'NAME'};
+        $name.="_HARN" if ( defined($d{'HARNESSTYPE'}) ); # Annotated bodge for missing harness feature
+        $dat.="Text GLabel $x $y $orientation 70 ${shape} ~\n${name}\n";
 	  }
 	  elsif($d{'RECORD'} eq '16')
 	  {

--- a/convertschema.pl
+++ b/convertschema.pl
@@ -666,7 +666,7 @@ EOF
 		($x,$y)=rotate($x,$y,$partorientation{$globalp});
 		my $r=int(($d{'RADIUS'}||0)+(($d{'RADIUS_FRAC'}||0)/100000.0))*$f;
 		my $sa="0"; $sa="$1$2" if(defined($d{'STARTANGLE'}) && $d{'STARTANGLE'}=~m/(\d+)\.(\d)(\d+)/);
-		my $ea="360"; $ea="$1$2" if(defined($d{'ENDANGLE'}) && $d{'ENDANGLE'}=~m/(\d+)\.(\d)(\d+)/);
+		my $ea="3600"; $ea="$1$2" if(defined($d{'ENDANGLE'}) && $d{'ENDANGLE'}=~m/(\d+)\.(\d)(\d+)/);
 		my @liste=();
 		if(($ea-$sa)>=1800)
 		{

--- a/convertschema.pl
+++ b/convertschema.pl
@@ -1168,9 +1168,16 @@ EOF
   	  elsif($d{'RECORD'} eq '22') #No ERC
 	  {
         #RECORD=22|OWNERPARTID=  -1|OWNERINDEX=   0|ISACTIVE=T|LINENO=1833|LOCATION.X=630|LOCATION.Y=480|SUPPRESSALL=T|SYMBOL=Thin Cross|
-        my $x=($d{'LOCATION.X'}*$f);
-		my $y=$sheety-($d{'LOCATION.Y'}*$f);
-    	$dat.="NoConn ~ $x $y\n";
+        if(defined($d{'LOCATION.X'}))
+        {
+          my $x=($d{'LOCATION.X'}*$f);
+		  my $y=$sheety-($d{'LOCATION.Y'}*$f);
+    	  $dat.="NoConn ~ $x $y\n";
+        }
+        else
+        {
+          print "Error: No ERC without position !  $b\n";
+        }
       }
 	  elsif($d{'RECORD'} =~m/^(10|14)$/) # Rectangle
 	  {

--- a/convertschema.pl
+++ b/convertschema.pl
@@ -805,7 +805,7 @@ EOF
       }
 	  elsif($d{'RECORD'} eq '33') # Sheet Symbol
 	  {
-        $prevfilename=$d{'TEXT'} if($d{'RECORD'} eq '33'); $prevfilename=~s/\.SchDoc/-SchDoc\.sch/;	
+        $prevfilename=$d{'TEXT'} if($d{'RECORD'} eq '33'); $prevfilename=~s/\.SchDoc/-SchDoc\.sch/i;	
 	    $dat="$symbol\nF0 \"$prevname\" 60\nF1 \"$prevfilename\" 60\n\$EndSheet\n";
 		$rootlibraries{"$short-cache.lib"}=1;
 	  }	  

--- a/convertschema.pl
+++ b/convertschema.pl
@@ -1338,7 +1338,7 @@ EOF
   }
   foreach my $part (sort keys %parts)
   {
-    #next if(!defined($partcomp{$part}));
+    next if(!defined($partcomp{$part}));
     print OUT "\$Comp\n";
 	#print "Reference: $part -> $globalreference{$part}\n";
 	print OUT "L $partcomp{$part} ".($globalreference{$part}||"IC$ICcount")."\n"; # IC$ICcount\n";

--- a/convertschema.pl
+++ b/convertschema.pl
@@ -54,7 +54,7 @@ our $timestamp=$start_time;  # this value gets decreased every time we need a un
 my %hvmap=("0"=>"H","1"=>"V","2"=>"H","3"=>"V");
 our %uniquereferences=();
 my %myrot=("0"=>"0","90"=>"1","270"=>"2");
-my %iotypes=("0"=>"BiDi","1"=>"Input","2"=>"Output"); # Others unknown yet
+my %iotypes=("0"=>"BiDi","1"=>"Output","2"=>"Input"); # Others unknown yet
 my %partparams=();
 
 #Reads a file with one function


### PR DESCRIPTION
Several small but significant improvements to schematic conversion
* Cope with SCHDOC files filenames case-insensitively (this fixes top level sheet references)
* Add support for ports
* Add support for sheet entries
* Add 'rough' support for elliptical arcs (ignoring the 2nd radius, but useful/perfect for some symbols)
* Improve reference labels (eg =Value)
* other minor "implementation level" fixes to reduce code level warnings
