### PR TITLE
Many more schematics changes

### DIFF
--- a/convertschema.pl
+++ b/convertschema.pl
@@ -648,9 +648,12 @@ EOF
 	  
 	  }
 	
-	  elsif($d{'RECORD'} eq '6') # Polyline
 	  {
+      elsif($d{'RECORD'} eq '6'|| $d{'RECORD'} eq '5') # Polyline or Bezier!
+	  {
+        #RECORD=5|OWNERINDEX=183|ISNOTACCESIBLE=T|INDEXINSHEET=12|OWNERPARTID=1|LINEWIDTH=1|COLOR=16711680|LOCATIONCOUNT=2|X1=464|Y1=943|X2=466|Y2=946
         #RECORD= 6|OWNERPARTID=   1|OWNERINDEX=1468|LINEWIDTH=1|LOCATIONCOUNT=2|OWNERINDEX=1468|X1=440|X2=440|Y1=1210|Y2=1207|
+        print "WARNING: Bezier paths are not supported in KiCad - creating a basic polyline through the control points instead\n" if ( $d{'RECORD'} eq '5' );
 		my $fill=(defined($d{'ISSOLID'})&&$d{'ISSOLID'} eq 'T')?"F":"N";
 		my $cmpd="P ".($d{'LOCATIONCOUNT'}||0)." 0 1 ".($d{'LINEWIDTH'}||1)."0 ";
 		foreach my $i(1 .. $d{'LOCATIONCOUNT'})

--- a/convertschema.pl
+++ b/convertschema.pl
@@ -1159,7 +1159,7 @@ EOF
         #RECORD=41|OWNERINDEX=1293|INDEXINSHEET=-1|OWNERPARTID=-1|LOCATION.X=845|LOCATION.Y=310|COLOR=8388608|FONTID=1|TEXT==Value|NAME=Comment|UNIQUEID=ROAWIONW
 		#my $ts=uniqueid2timestamp($d{'UNIQUEID'});
 	    #print "UNIQ: $d{UNIQUEID} -> $ts\n";
-        $partparams{$d{'NAME'}}=$d{'TEXT'};
+        $partparams{lc($d{'NAME'})}=$d{'TEXT'};
         if ( !( defined($d{'ISHIDDEN'}) && $d{'ISHIDDEN'} eq 'T') )
         {
           if(($d{'NAME'}||"") eq "Comment")
@@ -1173,7 +1173,7 @@ EOF
                 if ( substr($value,0,1) eq '=' ) # It's an xref - look it up
                 {
                     my $paramname = substr($value,1);
-                    $value = $partparams{$paramname} || $value;
+                    $value = $partparams{lc($paramname)} || $value;
                 }
                 push @{$parts{$globalp}},"F 1 \"$value\" $orient $x $y 60  0000 $dir\n"; #L BNN
                 push @{$parts{$globalp}},"F 2 \"\" H $x $y 60  0000 C CNN\n";

--- a/convertschema.pl
+++ b/convertschema.pl
@@ -709,18 +709,20 @@ EOF
 		my $LINEWIDTH=$d{LINEWIDTH}||1;
 		drawcomponent "C $x $y ".(($d{'RADIUS'}||0)*$f)." 0 1 $LINEWIDTH"."0 $fill\n";
 	  }
-      elsif($d{'RECORD'} eq '12' || $d{'RECORD'} eq '11') # Arc or Elliptical arc (we ignore the secondary axis as KiCad doesn't support it)
+      elsif($d{'RECORD'} eq '12' || $d{'RECORD'} eq '11') # Arc or Elliptical arc (we average the axes as KiCad doesn't support it)
 	  {
 	    #RECORD=12|ENDANGLE=180.000|LINEWIDTH=1|LOCATION.X=1065|LOCATION.Y=700|OWNERINDEX=738|RADIUS=5|STARTANGLE=90.000|		
         my $x=($d{'LOCATION.X'}*$f)-$relx;
 		my $y=($d{'LOCATION.Y'}*$f)-$rely;
 		($x,$y)=rotate($x,$y,$partorientation{$globalp});
-		my $r=int(($d{'RADIUS'}||0)+(($d{'RADIUS_FRAC'}||0)/100000.0))*$f;
+		my $r=int((($d{'RADIUS'}||0)+(($d{'RADIUS_FRAC'}||0)/100000.0))*$f);
 		my $sa="0"; $sa="$1$2" if(defined($d{'STARTANGLE'}) && $d{'STARTANGLE'}=~m/(\d+)\.(\d)(\d+)/);
 		my $ea="3600"; $ea="$1$2" if(defined($d{'ENDANGLE'}) && $d{'ENDANGLE'}=~m/(\d+)\.(\d)(\d+)/);
         if ( $d{'RECORD'} eq '11' )
         {
-            print "WARNING: Elliptical arcs are not supported in KiCad - creating circular arc using primary radius only\n";
+            my $sc=int((($d{'SECONDARYRADIUS'}||0)+(($d{'SECONDARYRADIUS_FRAC'}||0)/100000.0))*$f);
+            $r=($r+$sc)/2;
+            print "WARNING: Elliptical arcs are not supported in KiCad - creating circular arc using average radius instead\n";
         }
         $ea+=3600 if ( $sa > $ea );
 		my @liste=();

--- a/convertschema.pl
+++ b/convertschema.pl
@@ -54,7 +54,7 @@ our $timestamp=$start_time;  # this value gets decreased every time we need a un
 my %hvmap=("0"=>"H","1"=>"V","2"=>"H","3"=>"V");
 our %uniquereferences=();
 my %myrot=("0"=>"0","90"=>"1","270"=>"2");
-my %iotypes=("0"=>"BiDi","1"=>"Output","2"=>"Input"); # Others unknown yet
+my %iotypes=("0"=>"BiDi","1"=>"Output","2"=>"Input","3"=>"BiDi"); # Others unknown yet (0 is really 'unspecified' in Altium)
 my %partparams=();
 
 #Reads a file with one function
@@ -1377,14 +1377,17 @@ EOF
         #RECORD=18|INDEXINSHEET=75|OWNERPARTID=-1|STYLE=3|IOTYPE=1|ALIGNMENT=1|WIDTH=60|LOCATION.X=510|LOCATION.Y=990|COLOR=128|FONTID=1|AREACOLOR=8454143|TEXTCOLOR=128|NAME=ADC_VIN|UNIQUEID=ANXOUWEQ|HEIGHT=10
         #RECORD=18|INDEXINSHEET=73|OWNERPARTID=-1|STYLE=3|ALIGNMENT=1|WIDTH=45|LOCATION.X=625|LOCATION.Y=325|COLOR=128|FONTID=1|AREACOLOR=8454143|TEXTCOLOR=128|NAME=GPIO_IF|HARNESSTYPE=GPIO|UNIQUEID=RNYSNNOD|HEIGHT=10
         # No support for HARNESSTYPE yet (KiCad doesn't have such a feature)  We could instantiate lots of Ports as per the .Hardness file definition, but how would we lay them out?
-        # Location for Input/Output works, but for BiDi it doesn't connect - need some manual adjustment, as we can't use the WIDTH property in a KiCad global label
         my $x=($d{'LOCATION.X'}*$f);
         my $y=$sheety-($d{'LOCATION.Y'}*$f);
-        my $orientation=$d{'ALIGNMENT'}+1 || 0; # Altium seems to ignore this for harnesses?
+        my $orientation=($d{'ALIGNMENT'}||0)>2 ? 0:2; # Altium seems to ignore this for harnesses?
         my $shape=$iotypes{$d{'IOTYPE'} || 0 }; # Altium never seems to write out IOTYPE=0 for BiDi's
-        $name.="_HARN" if ( defined($d{'HARNESSTYPE'}) ); # Annotated bodge for missing harness feature
-        $dat.="Text GLabel $x $y $orientation 70 ${shape} ~\n${name}\n";
+        #$x += $d{'WIDTH'}*10 ; # WRONG for ports on the "right side" of components (which need to be taggead as 'left' types too) - but we can't know that, as it's not encoded in the Altium file!
+        print "WARNING: Port orientation may be incorrect and thus unconnected - ports on the 'left' of wires may need moving and orientation flipping\n";
         my $name=$d{'NAME'}; $name=~s/((.\\)+)/\~$1\~/g; $name=~s/(.)\\/$1/g; 
+        my $labeltype="GLabel";
+        my $size=$fontsize{$d{'FONTID'}}*6;
+        $name.="_HARN", $labeltype="HLabel" if ( defined($d{'HARNESSTYPE'}) ); # Annotated bodge for missing harness feature
+        $dat.="Text $labeltype $x $y $orientation $size ${shape} ~\n${name}\n";
 	  }
 	  elsif($d{'RECORD'} eq '16') # sheet entry
 	  {
@@ -1392,17 +1395,19 @@ EOF
         # RECORD=16|OWNERINDEX=77|OWNERPARTID=-1|SIDE=1|DISTANCEFROMTOP=21|COLOR=128|AREACOLOR=8454143|TEXTCOLOR=128|TEXTFONTID=1|TEXTSTYLE=Full|NAME=Ethernet_IF|HARNESSTYPE=Ethernet|UNIQUEID=TVQYSGEL|STYLE=3|ARROWKIND=Block & Triangle
         # Sides are: 0=left, 1=right, 2=top, 3=bottom - only left/right tested
         my $x=$relx;
-        my $y=$sheety-($rely - (($d{'DISTANCEFROMTOP'}*10+($d{DISTANCEFROMTOP_FRAC1}||0)/100000.0)*$f));
+        my $y=$sheety-$rely;
+        my $distance=(($d{'DISTANCEFROMTOP'}||0)*10+($d{'DISTANCEFROMTOP_FRAC1'}||0)/100000.0)*$f;
+        my $side=$d{'SIDE'}||0;
         my $shape=$iotypes{$d{'IOTYPE'} || 0 };
         my $name=$d{'NAME'};  $name=~s/((.\\)+)/\~$1\~/g; $name=~s/(.)\\/$1/g; 
         my $orient=0;
-        $orient = 2 if ( ($d{'SIDE'}||0) eq '0' );
-        $orient = 1 if ( ($d{'SIDE'}||0) eq '2' );
-        $orient = 3 if ( ($d{'SIDE'}||0) eq '3' );
-        $x+=$relw if ( $orient == 0 );
-        $y+=$relh if ( $orient % 2 == 1 );
+        $orient = 2, $y+=$distance            if ( $side eq '0' );
+        $orient = 0, $y+=$distance, $x+=$relw if ( $side eq '1' );
+        $orient = 3, $x+=$distance            if ( $side eq '2' );
+        $orient = 1, $x+=$distance, $y+=$relh if ( $side eq '3' );
         $name.="_HARN" if ( defined($d{'HARNESSTYPE'}) ); # Annotated bodge for missing harness feature
-        $dat.="Text HLabel $x $y ${orient} 70 ${shape} ~\n${name}\n";
+        my $size=$fontsize{$d{'TEXTFONTID'}}*6;
+        $dat.="Text HLabel $x $y ${orient} $size ${shape} ~\n${name}\n";
 	  }
   	  elsif($d{'RECORD'} eq '37') # Entry Wire Line / Bus connector
 	  {

--- a/convertschema.pl
+++ b/convertschema.pl
@@ -648,7 +648,22 @@ EOF
 	  
 	  }
 	
+      elsif($d{'RECORD'} eq '3') # Pin symbol
 	  {
+        #|RECORD=3|OWNERINDEX=1989|ISNOTACCESIBLE=T|INDEXINSHEET=9|OWNERPARTID=1|SYMBOL=1|LOCATION.X=1145|LOCATION.Y=821|SCALEFACTOR=10
+        my $x=($d{'LOCATION.X'}*$f)-$relx;
+        my $y=($d{'LOCATION.Y'}*$f)-$rely;
+        ($x,$y)=rotate($x,$y,$partorientation{$globalp});
+        if ( $d{'SYMBOL'} eq '1' )
+        {
+            # A 'Not' symbol - a small circle
+            drawcomponent "C $x $y ".(($d{'SCALEFACTOR'}||10)*$f/5.0)." 0 1 10 N\n";
+        }
+        else
+        {
+            print "WARNING: Pin symbol type $d{'SYMBOL'} not understood - IGNORING!\n";
+        }
+      }
       elsif($d{'RECORD'} eq '6'|| $d{'RECORD'} eq '5') # Polyline or Bezier!
 	  {
         #RECORD=5|OWNERINDEX=183|ISNOTACCESIBLE=T|INDEXINSHEET=12|OWNERPARTID=1|LINEWIDTH=1|COLOR=16711680|LOCATIONCOUNT=2|X1=464|Y1=943|X2=466|Y2=946

--- a/convertschema.pl
+++ b/convertschema.pl
@@ -1204,7 +1204,7 @@ EOF
               push @{$parts{$globalp}},"F 3 \"\" H $x $y 60  0000 C CNN\n";
               }
           }
-          elsif(defined($d{'LOCATION.X'}))
+          elsif(defined($d{'LOCATION.X'}) && $d{'LOCATION.Y'} >=0 )
           {
             #print "Field $d{'NAME'} found on line 1093\n";
             my $x=(($d{'LOCATION.X'}||0)*$f);

--- a/convertschema.pl
+++ b/convertschema.pl
@@ -1134,7 +1134,9 @@ EOF
         my $x=($d{'LOCATION.X'}*$f);
 		my $y=$sheety-($d{'LOCATION.Y'}*$f);
 		my $orientation=$d{'ORIENTATION'} || 0;
-    	$dat.="Text Label $x $y $orientation 70 ~\n$d{TEXT}\n" if($d{'TEXT'} ne "");
+        my $size=$fontsize{$d{'FONTID'}}*6;
+        my $name=$d{'TEXT'}||"";  $name=~s/((.\\)+)/\~$1\~/g; $name=~s/(.)\\/$1/g; 
+    	$dat.="Text Label $x $y $orientation $size ~\n$name\n" if($d{'TEXT'} ne "");
       }
 	  elsif($d{'RECORD'} eq '34') #Designator
 	  {
@@ -1380,9 +1382,9 @@ EOF
         my $y=$sheety-($d{'LOCATION.Y'}*$f);
         my $orientation=$d{'ALIGNMENT'}+1 || 0; # Altium seems to ignore this for harnesses?
         my $shape=$iotypes{$d{'IOTYPE'} || 0 }; # Altium never seems to write out IOTYPE=0 for BiDi's
-        my $name=$d{'NAME'};
         $name.="_HARN" if ( defined($d{'HARNESSTYPE'}) ); # Annotated bodge for missing harness feature
         $dat.="Text GLabel $x $y $orientation 70 ${shape} ~\n${name}\n";
+        my $name=$d{'NAME'}; $name=~s/((.\\)+)/\~$1\~/g; $name=~s/(.)\\/$1/g; 
 	  }
 	  elsif($d{'RECORD'} eq '16') # sheet entry
 	  {
@@ -1392,7 +1394,7 @@ EOF
         my $x=$relx;
         my $y=$sheety-($rely - (($d{'DISTANCEFROMTOP'}*10+($d{DISTANCEFROMTOP_FRAC1}||0)/100000.0)*$f));
         my $shape=$iotypes{$d{'IOTYPE'} || 0 };
-        my $name=$d{'NAME'};
+        my $name=$d{'NAME'};  $name=~s/((.\\)+)/\~$1\~/g; $name=~s/(.)\\/$1/g; 
         my $orient=0;
         $orient = 2 if ( ($d{'SIDE'}||0) eq '0' );
         $orient = 1 if ( ($d{'SIDE'}||0) eq '2' );

--- a/convertschema.pl
+++ b/convertschema.pl
@@ -1332,17 +1332,21 @@ EOF
 	  }
 	  elsif($d{'RECORD'} eq '28' || $d{'RECORD'} eq '209') # Text Frame
 	  {
+        sub min ($$) { $_[$_[0] > $_[1]] }
   		my $x=($d{'LOCATION.X'}*$f);
 		my $y=$sheety-($d{'LOCATION.Y'}*$f);
 		#my $x=($d{'LOCATION.X'}*$f)-$relx;
 		#my $y=($d{'LOCATION.Y'}*$f)-$rely;
-        ($x,$y)=rotate($x,$y,$partorientation{$globalp});
-		my $cx=($d{'CORNER.X'}*$f)-$relx;
-		my $cy=($d{'CORNER.Y'}*$f)-$rely;
-		($cx,$cy)=rotate($cx,$cy,$partorientation{$globalp});
-		my $text=$d{'TEXT'}; $text=~s/\~1/\~/g; $text=~s/ /\~/g;
+        #($x,$y)=rotate($x,$y,$partorientation{$globalp});
+		my $cx=($d{'CORNER.X'}*$f);
+		my $cy=$sheety-($d{'CORNER.Y'}*$f);
+		#($cx,$cy)=rotate($cx,$cy,$partorientation{$globalp});
+        my $text=$d{'TEXT'}; $text=~s/\~1/  /g; $text=~s/ /\~/g if ( ($d{'WORDWRAP'}||'N') eq 'N' );
         my $o=$d{'ORIENTATION'} || 0;
-   	    $dat.="Text Label $x $y $o 70 ~\n$text\n";
+        $x=$x<$cx?$x:$cx;
+        $y=$y<$cy?$y:$cy;
+        my $size=$fontsize{$d{'FONTID'}}*6;
+   	    $dat.="Text Label $x $y $o $size ~\n$text\n";
 		#drawcomponent "T 0 $x $y 100 0 1 1 $text 1\n";
 		#!!! Line-break, Alignment, ...
       }	  


### PR DESCRIPTION
A bumper stack of 9 commits comprising the past 2 days work - lots of small detail changes, including:
  * Support for global references in labels  (no more '=Project' etc appearing)
  * Very crude support for beziers - just as a polyline
  * Embryonic support for pin symbols - for now, just the "not" symbol on a pin, which was critical for me.
  * Mild improvement to the elliptical arc support
  * Add support for overbars so altiu, backslash notation is converted to kicad grouped tilde notation
  * Change reference matching to be case insensitive, as Altium seems to be (more labels now work)
  * Hide junk that Altium seems to dump off the bottom of the page
  * More tweaks to port and sheet entry support, with a big caveat (see commit message on that commit)
  * Improvements to comment block handling