### PR TITLE
Improved path setup

### DIFF
--- a/altium2kicad
+++ b/altium2kicad
@@ -2,12 +2,16 @@
 
 set -e
 
-if [ -z "$(ls *.PCBDOC)" -a -z "$(ls *.SCHDOC)" ]; then
+if [ -z "$(ls *.[Pp][Cc][Bb][Dd][Oo][Cc])" -a -z "$(ls *.[Ss][Cc][Hh][Dd][Oo][Cc])" ]; then
 	echo "No altium pcb or schematic files in current working directory!" >&2
 	exit 1
 fi
 
-export PERL5LIB=$PERL5LIB:$(realpath $(dirname $(which $0))/../lib/perl)
+# Get real directory of this script
+MYPATH=$(dirname $(realpath $0))
+export PERL5LIB=$PERL5LIB:$MYPATH/../lib/perl
+# Ensure access to other scripts
+export PATH=$MYPATH:$PATH
 
 a2k-unpack
 a2k-convertschema


### PR DESCRIPTION
I had some issues with the path configuration:
- The designfiles I got were named  PcbDoc and SchDoc -> improved 'ls' parameters;
- I made a symbolic link to /opt/altium2kicad/bin/altium2kicad and the other scripts could not be found -> update path inside script.