### PR TITLE
Coping with active-low (bar) nets, in the same way the schematic converter does.

### DIFF
--- a/convertpcb.pl
+++ b/convertpcb.pl
@@ -1027,7 +1027,7 @@ sub HandleTrack($$$$)
 	}
 	else
 	{
-	  print OUT "  (segment (start $x1 $y1) (end $x2 $y2) (width $width) (layer $layer) (net 1))\n";
+	  print OUT "  (segment (start $x1 $y1) (end $x2 $y2) (width $width) (layer $layer) (net $net))\n";
 	}
 	
 	# Automated verification against the Gerbers

--- a/convertpcb.pl
+++ b/convertpcb.pl
@@ -1860,6 +1860,7 @@ foreach my $filename(@files)
 	assertdata("Net",$_[3],"ID",$_[3]);
 	assertdata("Net",$_[3],"INDEXFORSAVE",$_[3]);
 	assertdata("Net",$_[3],$_,$_[0]{$_}) foreach(keys %{$_[0]});
+	$name=~s/((.\\)+)/\~$1\~/g; $name=~s/(.)\\/$1/g; 
 	$name=~s/\\//g;
         $name=~s/ //g;
 	$netnames{$line}=$name;
@@ -2002,7 +2003,13 @@ EOF
     (uvia_drill 0.127)
 EOF
 ;
-    print OUT "    (add_net \"$_\")\n" foreach(sort keys %{$netclass{$class}});
+    foreach my $name(sort keys %{$netclass{$class}})
+    {
+      $name=~s/((.\\)+)/\~$1\~/g; $name=~s/(.)\\/$1/g;
+      $name=~s/\\//g;
+	  $name=~s/ //g;
+      print OUT "    (add_net \"$name\")\n"
+    }
     print OUT "  )\n";
   }
 


### PR DESCRIPTION
The schematic converter converts A\B\C\ to ~ABC~ as required, but the PCB converter didn't - so copy that logic, otherwise the PCB file won't load in to KiCad.
Also fix the fact everything appears to be hard tagged as net 1 which isn't helpful.
